### PR TITLE
Remove Spaces from API key. 

### DIFF
--- a/pyweather.py
+++ b/pyweather.py
@@ -870,9 +870,9 @@ except FileNotFoundError:
         sys.exit()
         
 # API keys shoudn't have spaces. Fixes #78.
-# Just in case, let's also remove newlines.
+# Just in case, let's also remove tabs and newlines.
 
-apikey = apikey.replace(" ","").replace("\n","")
+apikey = apikey.replace(" ","").replace("\n","").replace("\t","")
 
 # Validate the user's API key for the full API key validation - Section 16
 if validateAPIKey == True:

--- a/setup.py
+++ b/setup.py
@@ -762,8 +762,8 @@ input()
 print("Please input your API key below.")
 apikey_input = str(input("Input here: ")).replace(" ","").replace("\n","").replace("\t","")
 logger.debug("apikey_input: %s" % apikey_input)
-print("", "Just to confirm, the API key you gave me was: '" + apikey_input
-      + "'", sep="\n")
+print("", "Just to confirm, the API key you gave me was: " + apikey_input
+      + ".", sep="\n")
 print("Please double check your input, and confirm in the dialogue below.")
 apikey_confirm = input("Is the API key right? Yes or no: ").lower()
 logger.debug("apikey_confirm: %s" % apikey_confirm)
@@ -773,8 +773,8 @@ if apikey_confirm == "no":
         print("","Please input your API key below.", sep="\n")
         apikey_input = str(input("Input here: ")).replace(" ","").replace("\n","").replace("\t","")
         logger.debug("apikey_input: %s" % apikey_input)
-        print("Just to confirm, the API key you gave me was: '" + apikey_input
-              + "'")
+        print("Just to confirm, the API key you gave me was: " + apikey_input
+              + ".")
         apikey_confirm = input("Is the API key right? Yes or no: ").lower()
         if apikey_confirm == "yes":
             break

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ _______
 |               |           @ # .`
 '''
 
-
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ _______
 |               |           @ # .`
 '''
 
+
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/setup.py
+++ b/setup.py
@@ -759,10 +759,10 @@ print("In the table to the left of the page, copy the text that's under Key ID."
 "Press any key when you are done and ready.", sep="\n")
 input()
 print("Please input your API key below.")
-apikey_input = input("Input here: ")
+apikey_input = str(input("Input here: ")).replace(" ","").replace("\n","").replace("\t","")
 logger.debug("apikey_input: %s" % apikey_input)
-print("", "Just to confirm, the API key you gave me was: " + apikey_input
-      + ".", sep="\n")
+print("", "Just to confirm, the API key you gave me was: '" + apikey_input
+      + "'", sep="\n")
 print("Please double check your input, and confirm in the dialogue below.")
 apikey_confirm = input("Is the API key right? Yes or no: ").lower()
 logger.debug("apikey_confirm: %s" % apikey_confirm)
@@ -770,10 +770,10 @@ if apikey_confirm == "no":
     while True:
         logger.debug("User now re-entering key...")
         print("","Please input your API key below.", sep="\n")
-        apikey_input = input("Input here: ")
+        apikey_input = str(input("Input here: ")).replace(" ","").replace("\n","").replace("\t","")
         logger.debug("apikey_input: %s" % apikey_input)
-        print("Just to confirm, the API key you gave me was: " + apikey_input
-              + ".")
+        print("Just to confirm, the API key you gave me was: '" + apikey_input
+              + "'")
         apikey_confirm = input("Is the API key right? Yes or no: ").lower()
         if apikey_confirm == "yes":
             break
@@ -892,7 +892,7 @@ while True:
         revalidateAPIkey = input("Input here: ").lower()
         if revalidateAPIkey == "yes":
             print("Enter in your API key below.")
-            apikey_input = input("Input here: ")
+            apikey_input = str(input("Input here: ")).replace(" ","").replace("\n","").replace("\t","")
             logger.debug("apikey_input: %s")
             print("Revalidating your API key...")
             continue


### PR DESCRIPTION
This should (in theory) remove any extra white space from the API key. In the setup file; the key is shown to the user in single quotes in order to spot trailing white space (can be removed if needed).
Fixed #78 